### PR TITLE
Fix granule duration check, to allow shorter than 48 scans in a granule

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,6 @@
 
  - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
  - [ ] Tests added <!-- for all bug fixes or enhancements -->
- - [ ] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
- - [ ] Passes ``flake8 pyspectral`` <!-- remove if you did not edit any Python files -->
+ - [ ] Tests passed: Passes ``pytest nwcsafpps_runner`` <!-- for all non-documentation changes) -->
+ - [ ] Passes ``flake8 nwcsafpps_runner`` <!-- remove if you did not edit any Python files -->
  - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,13 +9,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ["windows-latest", "ubuntu-latest", "macos-latest"]
+        # os: ["windows-latest", "ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.7", "3.8"]
         experimental: [false]
-        include:
-          - python-version: "3.8"
-            os: "ubuntu-latest"
-            experimental: true
+        # include:
+        #   - python-version: "3.8"
+        #     os: "ubuntu-latest"
+        #     experimental: true
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/nwcsafpps_runner/pps_posttroll_hook.py
+++ b/nwcsafpps_runner/pps_posttroll_hook.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2018 - 2020 Adam.Dybbroe
+# Copyright (c) 2018 - 2021 Adam.Dybbroe
 
 # Author(s):
 
@@ -73,12 +73,14 @@ MANDATORY_FIELDS_FROM_YAML = {'level': 'data_processing_level',
                               'output_format': 'format',
                               'station': 'station'}
 
+SEC_DURATION_ONE_GRANULE = 1.779
 MIN_VIIRS_GRANULE_LENGTH_SECONDS = timedelta(seconds=60)
-MAX_VIIRS_GRANULE_LENGTH_SECONDS = timedelta(seconds=90)
+MAX_VIIRS_GRANULE_LENGTH_SECONDS = timedelta(seconds=88)
 # One nominal VIIRS granule is 48 scans. The duration of one scan is 1.779 seconds.
 # Thus one granule is 1.779*48 = 85.4 seconds long.
 # Sometimes an SDR granule may be shorter if one or more scans are missing.
 # https://ncc.nesdis.noaa.gov/documents/documentation/viirs-users-guide-tech-report-142a-v1.3.pdf
+# Check page 37!
 #
 
 
@@ -332,4 +334,4 @@ class PostTrollMessage(object):
         """Derive the scene/granule duration as a timedelta object."""
         starttime = self.metadata['start_time']
         endtime = self.metadata['end_time']
-        return (endtime - starttime)
+        return (endtime - starttime + timedelta(seconds=SEC_DURATION_ONE_GRANULE))

--- a/nwcsafpps_runner/pps_posttroll_hook.py
+++ b/nwcsafpps_runner/pps_posttroll_hook.py
@@ -73,6 +73,12 @@ MANDATORY_FIELDS_FROM_YAML = {'level': 'data_processing_level',
                               'output_format': 'format',
                               'station': 'station'}
 
+MIN_VIIRS_GRANULE_LENGTH_SECONDS = timedelta(seconds=60)
+MAX_VIIRS_GRANULE_LENGTH_SECONDS = timedelta(seconds=90)
+# One nominal VIIRS granule is 48 scans. The duration of one scan is 1.779 seconds.
+# Thus one granule is 1.779*48 = 85.4 seconds long.
+# Sometimes an SDR granule may be shorter if one or more scans are missing.
+
 
 class PPSPublisher(threading.Thread):
 
@@ -152,8 +158,8 @@ class PostTrollMessage(object):
         self.metadata = metadata
         self.status = status
         self._to_send = {}
-        self.viirs_granule_time_bounds = (timedelta(seconds=84), timedelta(seconds=87))
-
+        self.viirs_granule_time_bounds = (MIN_VIIRS_GRANULE_LENGTH_SECONDS,
+                                          MAX_VIIRS_GRANULE_LENGTH_SECONDS)
         # Check that the metadata has what is required:
         self.check_metadata_contains_mandatory_parameters()
         self.check_metadata_contains_filename()

--- a/nwcsafpps_runner/pps_posttroll_hook.py
+++ b/nwcsafpps_runner/pps_posttroll_hook.py
@@ -78,6 +78,8 @@ MAX_VIIRS_GRANULE_LENGTH_SECONDS = timedelta(seconds=90)
 # One nominal VIIRS granule is 48 scans. The duration of one scan is 1.779 seconds.
 # Thus one granule is 1.779*48 = 85.4 seconds long.
 # Sometimes an SDR granule may be shorter if one or more scans are missing.
+# https://ncc.nesdis.noaa.gov/documents/documentation/viirs-users-guide-tech-report-142a-v1.3.pdf
+#
 
 
 class PPSPublisher(threading.Thread):
@@ -309,7 +311,7 @@ class PostTrollMessage(object):
             return False
 
         delta_t = self.get_granule_duration()
-        LOG.debug("Scene length: %s", str(delta_t))
+        LOG.debug("Scene length: %s", str(delta_t.total_seconds()))
         if self.viirs_granule_time_bounds[0] < delta_t < self.viirs_granule_time_bounds[1]:
             LOG.info("VIIRS scene is a segment. Scene length = %s", str(delta_t))
             return True

--- a/nwcsafpps_runner/tests/test_pps_hook.py
+++ b/nwcsafpps_runner/tests/test_pps_hook.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2020 Pytroll developers
+# Copyright (c) 2020, 2021 Pytroll developers
 
 # Author(s):
 
@@ -33,7 +33,7 @@ from unittest.mock import patch, Mock, MagicMock
 import yaml
 import nwcsafpps_runner
 from nwcsafpps_runner.pps_posttroll_hook import MANDATORY_FIELDS_FROM_YAML
-
+from nwcsafpps_runner.pps_posttroll_hook import SEC_DURATION_ONE_GRANULE
 
 START_TIME1 = datetime.fromisoformat("2020-12-17T14:08:25.800000")
 END_TIME1 = datetime.fromisoformat("2020-12-17T14:09:50")
@@ -235,7 +235,7 @@ class TestPostTrollMessage(unittest.TestCase):
         delta_t = posttroll_message.get_granule_duration()
         self.assertIsInstance(delta_t, timedelta)
 
-        self.assertAlmostEqual(delta_t.total_seconds(), 84.2, places=5)
+        self.assertAlmostEqual(delta_t.total_seconds(), 85.979, places=5)
 
         metadata['start_time'] = START_TIME2
         metadata['end_time'] = END_TIME2
@@ -243,7 +243,7 @@ class TestPostTrollMessage(unittest.TestCase):
         posttroll_message = PostTrollMessage(0, metadata)
         delta_t = posttroll_message.get_granule_duration()
 
-        self.assertAlmostEqual(delta_t.total_seconds(), 82.8, places=5)
+        self.assertAlmostEqual(delta_t.total_seconds(), 84.579, places=5)
 
     @patch('nwcsafpps_runner.pps_posttroll_hook.PostTrollMessage.sensor_is_viirs')
     @patch('nwcsafpps_runner.pps_posttroll_hook.PostTrollMessage.check_metadata_contains_filename')
@@ -259,7 +259,14 @@ class TestPostTrollMessage(unittest.TestCase):
         metadata = self.metadata_with_start_and_end_times
 
         posttroll_message = PostTrollMessage(0, metadata)
-        delta_t = timedelta(seconds=82.8)
+        delta_t = timedelta(seconds=48*SEC_DURATION_ONE_GRANULE)  # 48 scans
+
+        with patch.object(PostTrollMessage, 'get_granule_duration', return_value=delta_t) as mock_method:
+            result = posttroll_message.is_segment()
+            self.assertTrue(result)
+
+        posttroll_message = PostTrollMessage(0, metadata)
+        delta_t = timedelta(seconds=47*SEC_DURATION_ONE_GRANULE)  # 47 scans
 
         with patch.object(PostTrollMessage, 'get_granule_duration', return_value=delta_t) as mock_method:
             result = posttroll_message.is_segment()


### PR DESCRIPTION
Signed-off-by: Adam.Dybbroe <a000680@c21856.ad.smhi.se>

<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 nwcsafpps_runner`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
