### PR TITLE
Make publish topic for pps posttroll hook patternable

### DIFF
--- a/examples/pps_hooks.yaml
+++ b/examples/pps_hooks.yaml
@@ -2,7 +2,10 @@ pps_hook:
     post_hook: !!python/object:nwcsafpps_runner.pps_posttroll_hook.PPSMessage
       description: "This is a pps post hook for PostTroll messaging"
       metadata:
-        publish_topic: "/my/pps/publish/topic/"
+        # the publish topic can be a pattern, and the allowed keys are the ones
+        # provided here, plus pps_product, module, pps_version, platform_name,
+        # orbit, sensor, start_time, end_time, filename, file_was_already_processed
+        publish_topic: "/my/pps/publish/topic/{sensor}"
         station: "mystation"
         output_format: "CF"
         level: "2"

--- a/nwcsafpps_runner/tests/test_pps_hook.py
+++ b/nwcsafpps_runner/tests/test_pps_hook.py
@@ -252,7 +252,7 @@ class TestPostTrollMessage(unittest.TestCase):
 
         socket_gethostname.return_value = 'TEST_SERVERNAME'
 
-        metadata = {'publish_topic': '/my/pps/publish/topic',
+        metadata = {'publish_topic': '/my/pps/publish/topic/{pps_product}/',
                     'output_format': 'CF',
                     'level': '2',
                     'variant': 'DR',
@@ -269,6 +269,32 @@ class TestPostTrollMessage(unittest.TestCase):
             result_message = posttroll_message.create_message('OK')
 
         expected_message_header = "/my/pps/publish/topic/UNKNOWN/"
+        self.assertEqual(expected_message_header, result_message['header'])
+
+    @patch('socket.gethostname')
+    def test_create_message_with_topic_pattern(self, socket_gethostname):
+        """Test creating a message with header/topic that is a pattern, type and content."""
+        from nwcsafpps_runner.pps_posttroll_hook import PostTrollMessage
+
+        socket_gethostname.return_value = 'TEST_SERVERNAME'
+
+        metadata = {'publish_topic': '/my/pps/publish/topic/{sensor}/{pps_product}/',
+                    'output_format': 'CF',
+                    'level': '2',
+                    'variant': 'DR',
+                    'geo_or_polar': 'polar',
+                    'software': 'NWCSAF-PPSv2018',
+                    'start_time': START_TIME1, 'end_time': END_TIME1,
+                    'sensor': 'viirs',
+                    'filename': '/tmp/xxx',
+                    'platform_name': 'npp'}
+
+        posttroll_message = PostTrollMessage(0, metadata)
+
+        with patch.object(PostTrollMessage, 'is_segment', return_value=False):
+            result_message = posttroll_message.create_message('OK')
+
+        expected_message_header = "/my/pps/publish/topic/viirs/UNKNOWN/"
         self.assertEqual(expected_message_header, result_message['header'])
 
     @patch('nwcsafpps_runner.pps_posttroll_hook.PostTrollMessage.check_metadata_contains_filename')


### PR DESCRIPTION
This PR allows the publish topic of pps posttroll hook to be a pattern which will be filled with some metadata.


 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest nwcsafpps_runner`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 nwcsafpps_runner`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
