### PR TITLE
Use orbit number from message.

### DIFF
--- a/nwcsafpps_runner/l1c_processing.py
+++ b/nwcsafpps_runner/l1c_processing.py
@@ -101,6 +101,7 @@ class L1cProcessor(object):
         self.nameservers = options.get('nameservers')
         if self.nameservers is not None and not isinstance(self.nameservers, list):
             self.nameservers = [self.nameservers]
+        self.orbit_number_from_msg = options.get('orbit_number_from_msg', False)
 
     def initialize(self, service):
         """Initialize the processor."""
@@ -123,6 +124,12 @@ class L1cProcessor(object):
         self.message_data = self._get_message_data(msg)
 
         level1_dataset = self.message_data.get('dataset')
+
+        if self.orbit_number_from_msg:
+            if 'orbit_number' in self.message_data:
+                self.orbit_number = int(self.message_data.get('orbit_number'))
+            else:
+                LOG.warning("You asked for orbit_number from the message, but its not there. Keep init orbit.")
 
         if len(level1_dataset) < 1:
             raise DatasetIsEmpty('No level-1 data in dataset!')

--- a/nwcsafpps_runner/tests/test_level1c_runner.py
+++ b/nwcsafpps_runner/tests/test_level1c_runner.py
@@ -69,6 +69,17 @@ viirs-l1c:
   output_dir: /san1/polar_in/lvl1c
 """
 
+TEST_YAML_CONTENT_VIIRS_ORBIT_NUMBER_FROM_MSG_OK = """
+viirs-l1c:
+  message_types: [/segment/SDR/1B]
+  publish_topic: [/segment/SDR/1C]
+  instrument: 'viirs'
+  num_of_cpus: 2
+
+  output_dir: /san1/polar_in/lvl1c
+  orbit_number_from_msg: True
+"""
+
 TEST_YAML_CONTENT_NAMESERVERS_OK = """
 seviri-l1c:
   message_types: [/1b/hrit/0deg]
@@ -98,6 +109,9 @@ TEST_INPUT_MSG_NO_START_TIME = """pytroll://1b/hrit/0deg dataset safusr.u@lxserv
 TEST_VIIRS_MSG_DATA = {'start_time': datetime(2021, 6, 1, 5, 43, 11, 100000), 'end_time': datetime(2021, 6, 1, 5, 44, 35, 300000), 'orbit_number': 49711, 'platform_name': 'Suomi-NPP', 'sensor': 'viirs', 'format': 'SDR', 'type': 'HDF5', 'data_processing_level': '1B', 'variant': 'DR', 'orig_orbit_number': 49710, 'dataset': [{'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/GMODO_npp_d20210601_t0543111_e0544353_b49711_c20210601055246487163_cspp_dev.h5', 'uid': 'GMODO_npp_d20210601_t0543111_e0544353_b49711_c20210601055246487163_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/GMTCO_npp_d20210601_t0543111_e0544353_b49711_c20210601055246379744_cspp_dev.h5', 'uid': 'GMTCO_npp_d20210601_t0543111_e0544353_b49711_c20210601055246379744_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVM01_npp_d20210601_t0543111_e0544353_b49711_c20210601055314738876_cspp_dev.h5', 'uid': 'SVM01_npp_d20210601_t0543111_e0544353_b49711_c20210601055314738876_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVM02_npp_d20210601_t0543111_e0544353_b49711_c20210601055314768881_cspp_dev.h5', 'uid': 'SVM02_npp_d20210601_t0543111_e0544353_b49711_c20210601055314768881_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVM03_npp_d20210601_t0543111_e0544353_b49711_c20210601055314798831_cspp_dev.h5', 'uid': 'SVM03_npp_d20210601_t0543111_e0544353_b49711_c20210601055314798831_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVM04_npp_d20210601_t0543111_e0544353_b49711_c20210601055314834323_cspp_dev.h5', 'uid': 'SVM04_npp_d20210601_t0543111_e0544353_b49711_c20210601055314834323_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVM05_npp_d20210601_t0543111_e0544353_b49711_c20210601055314869370_cspp_dev.h5', 'uid': 'SVM05_npp_d20210601_t0543111_e0544353_b49711_c20210601055314869370_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVM06_npp_d20210601_t0543111_e0544353_b49711_c20210601055314903613_cspp_dev.h5', 'uid': 'SVM06_npp_d20210601_t0543111_e0544353_b49711_c20210601055314903613_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVM07_npp_d20210601_t0543111_e0544353_b49711_c20210601055315994299_cspp_dev.h5', 'uid': 'SVM07_npp_d20210601_t0543111_e0544353_b49711_c20210601055315994299_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVM08_npp_d20210601_t0543111_e0544353_b49711_c20210601055314968487_cspp_dev.h5', 'uid': 'SVM08_npp_d20210601_t0543111_e0544353_b49711_c20210601055314968487_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVM09_npp_d20210601_t0543111_e0544353_b49711_c20210601055314998705_cspp_dev.h5', 'uid': 'SVM09_npp_d20210601_t0543111_e0544353_b49711_c20210601055314998705_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVM10_npp_d20210601_t0543111_e0544353_b49711_c20210601055315028952_cspp_dev.h5', 'uid': 'SVM10_npp_d20210601_t0543111_e0544353_b49711_c20210601055315028952_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVM11_npp_d20210601_t0543111_e0544353_b49711_c20210601055315058971_cspp_dev.h5', 'uid': 'SVM11_npp_d20210601_t0543111_e0544353_b49711_c20210601055315058971_cspp_dev.h5'}, {
     'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVM12_npp_d20210601_t0543111_e0544353_b49711_c20210601055315089629_cspp_dev.h5', 'uid': 'SVM12_npp_d20210601_t0543111_e0544353_b49711_c20210601055315089629_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVM13_npp_d20210601_t0543111_e0544353_b49711_c20210601055315115727_cspp_dev.h5', 'uid': 'SVM13_npp_d20210601_t0543111_e0544353_b49711_c20210601055315115727_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVM14_npp_d20210601_t0543111_e0544353_b49711_c20210601055315160850_cspp_dev.h5', 'uid': 'SVM14_npp_d20210601_t0543111_e0544353_b49711_c20210601055315160850_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVM15_npp_d20210601_t0543111_e0544353_b49711_c20210601055315191874_cspp_dev.h5', 'uid': 'SVM15_npp_d20210601_t0543111_e0544353_b49711_c20210601055315191874_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVM16_npp_d20210601_t0543111_e0544353_b49711_c20210601055315222054_cspp_dev.h5', 'uid': 'SVM16_npp_d20210601_t0543111_e0544353_b49711_c20210601055315222054_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/GIMGO_npp_d20210601_t0543111_e0544353_b49711_c20210601055245783942_cspp_dev.h5', 'uid': 'GIMGO_npp_d20210601_t0543111_e0544353_b49711_c20210601055245783942_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/GITCO_npp_d20210601_t0543111_e0544353_b49711_c20210601055245203321_cspp_dev.h5', 'uid': 'GITCO_npp_d20210601_t0543111_e0544353_b49711_c20210601055245203321_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVI01_npp_d20210601_t0543111_e0544353_b49711_c20210601055314313242_cspp_dev.h5', 'uid': 'SVI01_npp_d20210601_t0543111_e0544353_b49711_c20210601055314313242_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVI02_npp_d20210601_t0543111_e0544353_b49711_c20210601055314399749_cspp_dev.h5', 'uid': 'SVI02_npp_d20210601_t0543111_e0544353_b49711_c20210601055314399749_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVI03_npp_d20210601_t0543111_e0544353_b49711_c20210601055314485227_cspp_dev.h5', 'uid': 'SVI03_npp_d20210601_t0543111_e0544353_b49711_c20210601055314485227_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVI04_npp_d20210601_t0543111_e0544353_b49711_c20210601055314569515_cspp_dev.h5', 'uid': 'SVI04_npp_d20210601_t0543111_e0544353_b49711_c20210601055314569515_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVI05_npp_d20210601_t0543111_e0544353_b49711_c20210601055314653190_cspp_dev.h5', 'uid': 'SVI05_npp_d20210601_t0543111_e0544353_b49711_c20210601055314653190_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/GDNBO_npp_d20210601_t0543111_e0544353_b49711_c20210601055245009217_cspp_dev.h5', 'uid': 'GDNBO_npp_d20210601_t0543111_e0544353_b49711_c20210601055245009217_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/SVDNB_npp_d20210601_t0543111_e0544353_b49711_c20210601055314094964_cspp_dev.h5', 'uid': 'SVDNB_npp_d20210601_t0543111_e0544353_b49711_c20210601055314094964_cspp_dev.h5'}, {'uri': 'ssh://lxserv1043.smhi.se/san1/polar_in/direct_readout/npp/lvl1/npp_20210601_0536_49711/IVCDB_npp_d20210601_t0543111_e0544353_b49711_c20210601055314133571_cspu_pop.h5', 'uid': 'IVCDB_npp_d20210601_t0543111_e0544353_b49711_c20210601055314133571_cspu_pop.h5'}]}
 
+TEST_INPUT_MESSAGE_VIIRS_MSG = """pytroll://1b/viirs dataset safusr.u@lxserv1043.smhi.se 2021-05-18T14:28:54.154172 v1.01 application/json {"orbit_number": 49711, "data_type": "MSG4", "orig_platform_name": "MSG4", "start_time": "2021-05-18T14:15:00", "variant": "0DEG", "series": "MSG4", "platform_name": "Suomi-NPP", "channel": "", "nominal_time": "2021-05-18T14:15:00", "compressed": "", "origin": "172.18.0.248:9093", "dataset": [{"uri": "/san1/geo_in/0deg/H-000-MSG4__-MSG4________-_________-PRO______-202105181415-__", "uid": "H-000-MSG4__-MSG4________-_________-PRO______-202105181415-__"}, {"uri": "/san1/geo_in/0deg/H-000-MSG4__-MSG4________-HRV______-000001___-202105181415-__", "uid": "H-000-MSG4__-MSG4________-HRV______-000001___-202105181415-__"}], "sensor": ["seviri"]}"""
+
+TEST_INPUT_MESSAGE_VIIRS_NO_ORBIT_MSG = """pytroll://1b/viirs dataset safusr.u@lxserv1043.smhi.se 2021-05-18T14:28:54.154172 v1.01 application/json {"data_type": "MSG4", "orig_platform_name": "MSG4", "start_time": "2021-05-18T14:15:00", "variant": "0DEG", "series": "MSG4", "platform_name": "Suomi-NPP", "channel": "", "nominal_time": "2021-05-18T14:15:00", "compressed": "", "origin": "172.18.0.248:9093", "dataset": [{"uri": "/san1/geo_in/0deg/H-000-MSG4__-MSG4________-_________-PRO______-202105181415-__", "uid": "H-000-MSG4__-MSG4________-_________-PRO______-202105181415-__"}, {"uri": "/san1/geo_in/0deg/H-000-MSG4__-MSG4________-HRV______-000001___-202105181415-__", "uid": "H-000-MSG4__-MSG4________-HRV______-000001___-202105181415-__"}], "sensor": ["seviri"]}"""
 
 class MyFakePublisher(object):
 
@@ -177,6 +191,8 @@ class TestL1cProcessing(unittest.TestCase):
         self.config_minimum = create_config_from_yaml(TEST_YAML_CONTENT_OK_MINIMAL)
         self.config_viirs_ok = create_config_from_yaml(TEST_YAML_CONTENT_VIIRS_OK)
         self.config_complete_nameservers = create_config_from_yaml(TEST_YAML_CONTENT_NAMESERVERS_OK)
+        self.config_viirs_orbit_number_from_msg_ok = create_config_from_yaml(
+            TEST_YAML_CONTENT_VIIRS_ORBIT_NUMBER_FROM_MSG_OK)
 
     def test_check_service_is_supported(self):
 
@@ -303,6 +319,44 @@ class TestL1cProcessing(unittest.TestCase):
                              'GMODO_npp_d20210601_t0543111_e0544353_b49711_' +
                              'c20210601055246487163_cspp_dev.h5')
         self.assertEqual(l1c_proc.level1_files[0], expected_filepath)
+
+    @patch('nwcsafpps_runner.config.load_config_from_file')
+    @patch('nwcsafpps_runner.l1c_processing.cpu_count')
+    def test_orbit_number_from_msg_viirs(self, cpu_count, config):
+        """Test use orbit number from message."""
+
+        cpu_count.return_value = 1
+        config.return_value = self.config_viirs_orbit_number_from_msg_ok
+        myconfig_filename = '/tmp/my/config/file'
+
+        input_msg = Message.decode(rawstr=TEST_INPUT_MESSAGE_VIIRS_MSG)
+
+        with patch('nwcsafpps_runner.l1c_processing.ThreadPool'):
+            l1c_proc = L1cProcessor(myconfig_filename, 'viirs-l1c')
+            l1c_proc.run(input_msg)
+        expected_orbit_number = TEST_VIIRS_MSG_DATA.get('orbit_number')
+        self.assertEqual(l1c_proc.orbit_number, expected_orbit_number)
+
+    @patch('nwcsafpps_runner.config.load_config_from_file')
+    @patch('nwcsafpps_runner.l1c_processing.cpu_count')
+    def test_orbit_number_missing_in_msg_viirs(self, cpu_count, config):
+        """Test use orbit number but missing in message."""
+
+        cpu_count.return_value = 1
+        config.return_value = self.config_viirs_orbit_number_from_msg_ok
+        myconfig_filename = '/tmp/my/config/file'
+
+        input_msg = Message.decode(rawstr=TEST_INPUT_MESSAGE_VIIRS_NO_ORBIT_MSG)
+
+        with self.assertLogs('nwcsafpps_runner.l1c_processing', level='INFO') as cm:
+            with patch('nwcsafpps_runner.l1c_processing.ThreadPool'):
+                l1c_proc = L1cProcessor(myconfig_filename, 'viirs-l1c')
+                l1c_proc.run(input_msg)
+            expected_orbit_number = 99999
+            self.assertEqual(l1c_proc.orbit_number, expected_orbit_number)
+
+        self.assertEqual(cm.output[2], 'WARNING:nwcsafpps_runner.l1c_processing:You asked for orbit_number '
+                                       'from the message, but its not there. Keep init orbit.')
 
     @patch('nwcsafpps_runner.config.load_config_from_file')
     @patch('nwcsafpps_runner.l1c_processing.cpu_count')

--- a/nwcsafpps_runner/tests/test_level1c_runner.py
+++ b/nwcsafpps_runner/tests/test_level1c_runner.py
@@ -29,6 +29,7 @@ import unittest
 from posttroll.message import Message
 from datetime import datetime
 import yaml
+import tempfile
 
 from nwcsafpps_runner.message_utils import publish_l1c, prepare_l1c_message
 from nwcsafpps_runner.l1c_processing import check_message_okay
@@ -112,6 +113,7 @@ TEST_VIIRS_MSG_DATA = {'start_time': datetime(2021, 6, 1, 5, 43, 11, 100000), 'e
 TEST_INPUT_MESSAGE_VIIRS_MSG = """pytroll://1b/viirs dataset safusr.u@lxserv1043.smhi.se 2021-05-18T14:28:54.154172 v1.01 application/json {"orbit_number": 49711, "data_type": "MSG4", "orig_platform_name": "MSG4", "start_time": "2021-05-18T14:15:00", "variant": "0DEG", "series": "MSG4", "platform_name": "Suomi-NPP", "channel": "", "nominal_time": "2021-05-18T14:15:00", "compressed": "", "origin": "172.18.0.248:9093", "dataset": [{"uri": "/san1/geo_in/0deg/H-000-MSG4__-MSG4________-_________-PRO______-202105181415-__", "uid": "H-000-MSG4__-MSG4________-_________-PRO______-202105181415-__"}, {"uri": "/san1/geo_in/0deg/H-000-MSG4__-MSG4________-HRV______-000001___-202105181415-__", "uid": "H-000-MSG4__-MSG4________-HRV______-000001___-202105181415-__"}], "sensor": ["seviri"]}"""
 
 TEST_INPUT_MESSAGE_VIIRS_NO_ORBIT_MSG = """pytroll://1b/viirs dataset safusr.u@lxserv1043.smhi.se 2021-05-18T14:28:54.154172 v1.01 application/json {"data_type": "MSG4", "orig_platform_name": "MSG4", "start_time": "2021-05-18T14:15:00", "variant": "0DEG", "series": "MSG4", "platform_name": "Suomi-NPP", "channel": "", "nominal_time": "2021-05-18T14:15:00", "compressed": "", "origin": "172.18.0.248:9093", "dataset": [{"uri": "/san1/geo_in/0deg/H-000-MSG4__-MSG4________-_________-PRO______-202105181415-__", "uid": "H-000-MSG4__-MSG4________-_________-PRO______-202105181415-__"}, {"uri": "/san1/geo_in/0deg/H-000-MSG4__-MSG4________-HRV______-000001___-202105181415-__", "uid": "H-000-MSG4__-MSG4________-HRV______-000001___-202105181415-__"}], "sensor": ["seviri"]}"""
+
 
 class MyFakePublisher(object):
 
@@ -327,7 +329,7 @@ class TestL1cProcessing(unittest.TestCase):
 
         cpu_count.return_value = 1
         config.return_value = self.config_viirs_orbit_number_from_msg_ok
-        myconfig_filename = '/tmp/my/config/file'
+        myconfig_filename = tempfile.mktemp()
 
         input_msg = Message.decode(rawstr=TEST_INPUT_MESSAGE_VIIRS_MSG)
 
@@ -344,7 +346,7 @@ class TestL1cProcessing(unittest.TestCase):
 
         cpu_count.return_value = 1
         config.return_value = self.config_viirs_orbit_number_from_msg_ok
-        myconfig_filename = '/tmp/my/config/file'
+        myconfig_filename = tempfile.mktemp()
 
         input_msg = Message.decode(rawstr=TEST_INPUT_MESSAGE_VIIRS_NO_ORBIT_MSG)
 
@@ -365,7 +367,7 @@ class TestL1cProcessing(unittest.TestCase):
 
         cpu_count.return_value = 2
         config.return_value = self.config_complete_nameservers
-        myconfig_filename = '/tmp/my/config/file'
+        myconfig_filename = tempfile.mktemp()
 
         with patch('nwcsafpps_runner.l1c_processing.ThreadPool') as mock:
             mock.return_value = None


### PR DESCRIPTION
Use orbit number from message if configured.

Else hardcoded value in the initialiser is used which may cause problems in downstream processing eg. pps-runner.

 - [X] Closes #41  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [X] Tests passed: Passes ``pytest nwcsafpps_runner`` <!-- for all non-documentation changes) -->
 - [X] Passes ``flake8 nwcsafpps_runner`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
