### PR TITLE
Bugfix xml timestat from ascii

### DIFF
--- a/nwcsafpps_runner/utils.py
+++ b/nwcsafpps_runner/utils.py
@@ -646,6 +646,8 @@ def get_time_control_ascii_filename_candidates(pps_control_path, scene):
     norbit_candidates = [scene['orbit_number']]
     if sensors in ['modis', ]:
         norbit_candidates.append(0)
+    elif sensors in ['viirs', ]:
+        norbit_candidates.append(99999)
 
     infiles = []
     for norbit in norbit_candidates:

--- a/nwcsafpps_runner/utils.py
+++ b/nwcsafpps_runner/utils.py
@@ -642,12 +642,14 @@ def get_time_control_ascii_filename_candidates(pps_control_path, scene):
             st_times.append(atime.strftime("%Y%m%dT%H%M"))
             atime = atime + timedelta(seconds=60)
 
-    # PPSv2018 MODIS files have the orbit number set to "00000"!
+    # For VIIRS we often see a orbit number difference of 1:
     norbit_candidates = [scene['orbit_number']]
+    for idx in [1, -1]:
+        norbit_candidates.append(int(scene['orbit_number']) + idx)
+
+    # PPSv2018 MODIS files have the orbit number set to "00000"!
     if sensors in ['modis', ]:
         norbit_candidates.append(0)
-    elif sensors in ['viirs', ]:
-        norbit_candidates.append(99999)
 
     infiles = []
     for norbit in norbit_candidates:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2013 - 2021 Pytroll Community
+# Copyright (c) 2013 - 2022 Pytroll Community
 
 # Author(s):
 


### PR DESCRIPTION
This PR solves an issue with PPS time control files and orbit numbering.
PPSv2018 does not pick up the orbit number from the input posttroll message neither the MODIS EOS-HDF files, Therefore the PPS (level-1c and intermediate and final product) files have `00000` as orbit number in the file names. This result in no time-control found and the runner crashes.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest nwcsafpps_runner`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8 nwcsafpps_runner`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
