### PR TITLE
Fix find xml from l1c

### DIFF
--- a/bin/pps2018_runner.py
+++ b/bin/pps2018_runner.py
@@ -182,7 +182,7 @@ def pps_worker(scene, publish_q, input_msg, options):
             err_reader2.join()
 
         pps_control_path = my_env.get('STATISTICS_DIR', options.get('pps_statistics_dir', './'))
-        if "file4pps" in scene:
+        if use_l1c:
             # v2021
             xml_files = create_xml_timestat_from_lvl1c(scene, pps_control_path)
             xml_files += create_product_statistics_from_lvl1c(scene, pps_control_path)

--- a/bin/pps2018_runner.py
+++ b/bin/pps2018_runner.py
@@ -180,11 +180,18 @@ def pps_worker(scene, publish_q, input_msg, options):
             err_reader2.join()
 
         pps_control_path = my_env.get('STATISTICS_DIR', options.get('pps_statistics_dir', './'))
-        xml_files = create_xml_timestat_from_ascii(scene, pps_control_path)
-        xml_files = xml_files + get_product_statistics_files(pps_control_path,
-                                                             scene,
-                                                             options['product_statistics_filename'],
-                                                             options['pps_filetime_search_minutes'])
+        if "file4pps" in scene:
+            # v2021
+            xml_files = create_xml_timestat_from_lvl1c(scene, pps_control_path)
+            xml_files += create_product_statistics_from_lvl1c(scene, pps_control_path)
+        else:
+            #v2018
+            xml_files = create_xml_timestat_from_ascii(scene, pps_control_path)
+            xml_files = xml_files + get_product_statistics_files(pps_control_path,
+                                                                 scene,
+                                                                 options['product_statistics_filename'],
+                                                                 options['pps_filetime_search_minutes'])
+
         LOG.info("PPS summary statistics files: %s", str(xml_files))
 
         # The PPS post-hooks takes care of publishing the PPS cloud products

--- a/bin/pps2018_runner.py
+++ b/bin/pps2018_runner.py
@@ -41,6 +41,8 @@ from nwcsafpps_runner.utils import (METOP_NAME_LETTER, SATELLITE_NAME,
                                     SENSOR_LIST, NwpPrepareError, PpsRunError,
                                     create_pps_call_command,
                                     get_outputfiles, get_pps_inputfile,
+                                    create_xml_timestat_from_lvl1c,
+                                    create_product_statistics_from_lvl1c,
                                     get_sceneid, logreader, message_uid,
                                     prepare_pps_arguments, publish_pps_files,
                                     ready2run, terminate_process)
@@ -185,7 +187,7 @@ def pps_worker(scene, publish_q, input_msg, options):
             xml_files = create_xml_timestat_from_lvl1c(scene, pps_control_path)
             xml_files += create_product_statistics_from_lvl1c(scene, pps_control_path)
         else:
-            #v2018
+            # v2018
             xml_files = create_xml_timestat_from_ascii(scene, pps_control_path)
             xml_files = xml_files + get_product_statistics_files(pps_control_path,
                                                                  scene,

--- a/nwcsafpps_runner/tests/test_utils.py
+++ b/nwcsafpps_runner/tests/test_utils.py
@@ -73,6 +73,15 @@ def test_create_xml_timestat_from_lvl1c(tmp_path):
     assert len(res) == len(set(res))
     assert set(res) == set(expected)
 
+    scene = {}
+    #: Test xml files for timectrl no file4pps attribute
+    res = create_xml_timestat_from_lvl1c(scene, mydir_out)
+    assert res == []
+
+    #: Test xml files for products no file4pps attribute
+    res = create_product_statistics_from_lvl1c(scene, mydir_out)
+    assert res == []
+
 
 def test_outputfiles(tmp_path):
     """Test get_outputfiles.

--- a/nwcsafpps_runner/tests/test_utils.py
+++ b/nwcsafpps_runner/tests/test_utils.py
@@ -32,8 +32,7 @@ from nwcsafpps_runner.utils import get_product_statistics_files
 
 
 def test_create_xml_timestat_from_lvl1c(tmp_path):
-    """Test xml files that for a level1c file.
-    """
+    """Test xml files that for a level1c file."""
     #: Create temp_path
     mydir = tmp_path / "import"
     mydir.mkdir()
@@ -50,26 +49,24 @@ def test_create_xml_timestat_from_lvl1c(tmp_path):
         f1 = mydir / "S_NWC_{}_npp_82345_19820305T0715000Z_19820305T0730000Z{}".format(file_tag, typ)
         f1.write_text("test_file type {:s}".format(typ))
 
-    #: Test xml files without start time
-    typ = "xml"
+    #: Create the level1c and xml files
     create_files(mydir, "viirs", ".nc")
+    create_files(mydir_out, "CMAPROB", ".nc")
     create_files(mydir_out, "CMAPROB", "_statistics.xml")
     create_files(mydir_out, "CMIC", "_statistics.xml")
     create_files(mydir_out, "CTTH", "_statistics.xml")
     create_files(mydir_out, "timectrl", ".xml")
     create_files(mydir_out, "timectrl", "_dummy.xml")
-
     scene = {'file4pps': "S_NWC_viirs_npp_12345_19810305T0715000Z_19810305T0730000Z.nc"}
-    res = create_xml_timestat_from_lvl1c(scene, mydir_out)
-    print(res)
 
+    #: Test xml files for timectrl
+    res = create_xml_timestat_from_lvl1c(scene, mydir_out)
     expected = [os.path.join(mydir_out, "S_NWC_timectrl_npp_12345_19810305T0715000Z_19810305T0730000Z.xml")]
     assert len(res) == len(set(res))
     assert set(res) == set(expected)
 
-    #: Test xml files with start time
+    #: Test xml files for products
     res = create_product_statistics_from_lvl1c(scene, mydir_out)
-    print(res)
     expected = [os.path.join(mydir_out, "S_NWC_CMAPROB_npp_12345_19810305T0715000Z_19810305T0730000Z_statistics.xml"),
                 os.path.join(mydir_out, "S_NWC_CTTH_npp_12345_19810305T0715000Z_19810305T0730000Z_statistics.xml"),
                 os.path.join(mydir_out, "S_NWC_CMIC_npp_12345_19810305T0715000Z_19810305T0730000Z_statistics.xml")]

--- a/nwcsafpps_runner/utils.py
+++ b/nwcsafpps_runner/utils.py
@@ -704,8 +704,8 @@ def get_product_statistics_files(pps_control_path, scene, product_statistics_fil
     scene_start_time = scene['starttime']
     possible_filetimes = [scene_start_time]
     for nmin in range(1, max_abs_deviation_minutes + 1):
-        possible_filetimes.append(scene_start_time - timedelta(seconds=60*nmin))
-        possible_filetimes.append(scene_start_time + timedelta(seconds=60*nmin))
+        possible_filetimes.append(scene_start_time - timedelta(seconds=60 * nmin))
+        possible_filetimes.append(scene_start_time + timedelta(seconds=60 * nmin))
 
     for product_name in ['CMA', 'CT', 'CTTH', 'CPP', 'CMAPROB']:
         for start_time in possible_filetimes:

--- a/nwcsafpps_runner/utils.py
+++ b/nwcsafpps_runner/utils.py
@@ -589,23 +589,28 @@ def get_xml_outputfiles(path, platform_name, orb, st_time=''):
 
 def create_xml_timestat_from_lvl1c(scene, pps_control_path):
     """From lvl1c file create XML file and return a file list."""
-    return [create_pps_file_from_lvl1c(scene, pps_control_path, "timectrl", ".xml")]
+    if 'file4pps' in scene:
+        return [create_pps_file_from_lvl1c(scene['file4pps'], pps_control_path, "timectrl", ".xml")]
+    else:
+        return []
 
 
 def create_product_statistics_from_lvl1c(scene, pps_control_path):
     """From lvl1c file create product XML files and return a file list."""
-    glob_pattern = create_pps_file_from_lvl1c(scene, pps_control_path, "*", "_statistics.xml")
-    return glob(glob_pattern)
-
-
-def create_pps_file_from_lvl1c(scene, pps_control_path, name_tag, file_type):
-    """From lvl1c file create name_tag-file of type file_type."""
     if 'file4pps' in scene:
-        l1c_path, l1c_file = os.path.split(scene['file4pps'])
-        l1c_file_as_list = l1c_file.split("_")
-        l1c_file_as_list[2] = name_tag
-        l1c_file_as_list[-1] = l1c_file_as_list[-1].replace(".nc", file_type)
-        return os.path.join(pps_control_path, ("_").join(l1c_file_as_list))
+        glob_pattern = create_pps_file_from_lvl1c(scene['file4pps'], pps_control_path, "*", "_statistics.xml")
+        return glob(glob_pattern)
+    else:
+        return []
+
+
+def create_pps_file_from_lvl1c(l1c_file_name, pps_control_path, name_tag, file_type):
+    """From lvl1c file create name_tag-file of type file_type."""
+    l1c_path, l1c_file = os.path.split(l1c_file_name)
+    l1c_file_as_list = l1c_file.split("_")
+    l1c_file_as_list[2] = name_tag
+    l1c_file_as_list[-1] = l1c_file_as_list[-1].replace(".nc", file_type)
+    return os.path.join(pps_control_path, ("_").join(l1c_file_as_list))
 
 
 def create_xml_timestat_from_ascii(scene, pps_control_path):

--- a/nwcsafpps_runner/utils.py
+++ b/nwcsafpps_runner/utils.py
@@ -587,6 +587,27 @@ def get_xml_outputfiles(path, platform_name, orb, st_time=''):
     return filelist
 
 
+def create_xml_timestat_from_lvl1c(scene, pps_control_path):
+    """From lvl1c file create XML file and return a file list."""
+    return [create_pps_file_from_lvl1c(scene, pps_control_path, "timectrl", ".xml")]
+
+
+def create_product_statistics_from_lvl1c(scene, pps_control_path):
+    """From lvl1c file create product XML files and return a file list."""
+    glob_pattern = create_pps_file_from_lvl1c(scene, pps_control_path, "*", "_statistics.xml")
+    return glob(glob_pattern)
+
+
+def create_pps_file_from_lvl1c(scene, pps_control_path, name_tag, file_type):
+    """From lvl1c file create name_tag-file of type file_type."""
+    if 'file4pps' in scene:
+        l1c_path, l1c_file = os.path.split(scene['file4pps'])
+        l1c_file_as_list = l1c_file.split("_")
+        l1c_file_as_list[2] = name_tag
+        l1c_file_as_list[-1] = l1c_file_as_list[-1].replace(".nc", file_type)
+        return os.path.join(pps_control_path, ("_").join(l1c_file_as_list))
+
+
 def create_xml_timestat_from_ascii(scene, pps_control_path):
     """From ascii file(s) with PPS time statistics create XML file(s) and return a file list."""
     try:

--- a/nwcsafpps_runner/utils.py
+++ b/nwcsafpps_runner/utils.py
@@ -589,18 +589,18 @@ def get_xml_outputfiles(path, platform_name, orb, st_time=''):
 
 def create_xml_timestat_from_lvl1c(scene, pps_control_path):
     """From lvl1c file create XML file and return a file list."""
-    if 'file4pps' in scene:
+    try:
         return [create_pps_file_from_lvl1c(scene['file4pps'], pps_control_path, "timectrl", ".xml")]
-    else:
+    except KeyError:
         return []
 
 
 def create_product_statistics_from_lvl1c(scene, pps_control_path):
     """From lvl1c file create product XML files and return a file list."""
-    if 'file4pps' in scene:
+    try:
         glob_pattern = create_pps_file_from_lvl1c(scene['file4pps'], pps_control_path, "*", "_statistics.xml")
         return glob(glob_pattern)
-    else:
+    except KeyError:
         return []
 
 

--- a/nwcsafpps_runner/utils.py
+++ b/nwcsafpps_runner/utils.py
@@ -606,11 +606,13 @@ def create_product_statistics_from_lvl1c(scene, pps_control_path):
 
 def create_pps_file_from_lvl1c(l1c_file_name, pps_control_path, name_tag, file_type):
     """From lvl1c file create name_tag-file of type file_type."""
+    from trollsift import parse, compose
+    f_pattern = 'S_NWC_{name_tag}_{platform_id}_{orbit_number}_{start_time}Z_{end_time}Z{file_type}'
     l1c_path, l1c_file = os.path.split(l1c_file_name)
-    l1c_file_as_list = l1c_file.split("_")
-    l1c_file_as_list[2] = name_tag
-    l1c_file_as_list[-1] = l1c_file_as_list[-1].replace(".nc", file_type)
-    return os.path.join(pps_control_path, ("_").join(l1c_file_as_list))
+    data = parse(f_pattern, l1c_file)
+    data["name_tag"] = name_tag
+    data["file_type"] = file_type
+    return os.path.join(pps_control_path, compose(f_pattern, data))
 
 
 def create_xml_timestat_from_ascii(scene, pps_control_path):


### PR DESCRIPTION
For PPSv2021 when we have the level1c file, all other files produced by PPS can be derived from it. Use the level1c file to find the xml files.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest nwcsafpps_runner`` <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/main -- "*py" | flake8 --diff main`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
