### PR TITLE
Create the xml files for PPS time control

### DIFF
--- a/bin/pps2018_runner.py
+++ b/bin/pps2018_runner.py
@@ -42,11 +42,11 @@ from nwcsafpps_runner.utils import (METOP_NAME_LETTER, SATELLITE_NAME,
                                     create_pps_call_command,
                                     get_outputfiles, get_pps_inputfile,
                                     create_xml_timestat_from_lvl1c,
-                                    create_product_statistics_from_lvl1c,
+                                    find_product_statistics_from_lvl1c,
                                     get_sceneid, logreader, message_uid,
                                     prepare_pps_arguments, publish_pps_files,
                                     ready2run, terminate_process)
-from nwcsafpps_runner.utils import create_xml_timestat_from_ascii
+from nwcsafpps_runner.utils import create_xml_timestat_from_scene
 from nwcsafpps_runner.utils import get_product_statistics_files
 
 LOG = logging.getLogger(__name__)
@@ -185,10 +185,10 @@ def pps_worker(scene, publish_q, input_msg, options):
         if use_l1c:
             # v2021
             xml_files = create_xml_timestat_from_lvl1c(scene, pps_control_path)
-            xml_files += create_product_statistics_from_lvl1c(scene, pps_control_path)
+            xml_files += find_product_statistics_from_lvl1c(scene, pps_control_path)
         else:
             # v2018
-            xml_files = create_xml_timestat_from_ascii(scene, pps_control_path)
+            xml_files = create_xml_timestat_from_scene(scene, pps_control_path)
             xml_files = xml_files + get_product_statistics_files(pps_control_path,
                                                                  scene,
                                                                  options['product_statistics_filename'],

--- a/nwcsafpps_runner/prepare_nwp.py
+++ b/nwcsafpps_runner/prepare_nwp.py
@@ -41,7 +41,6 @@ from nwcsafpps_runner.utils import NwpPrepareError
 import logging
 LOG = logging.getLogger(__name__)
 
-
 LOG.debug("Path to prepare_nwp config file = %s", str(CONFIG_PATH))
 LOG.debug("Prepare_nwp config file = %s", str(CONFIG_FILE))
 OPTIONS = get_config(CONFIG_FILE)
@@ -191,7 +190,7 @@ def update_nwp(starttime, nlengths):
                       "topography available. Can't prepare NWP data")
             raise IOError('Failed getting static land-sea mask and topography')
 
-        tmp_result_filename = result_file + "_tmp"
+        tmp_result_filename = tmp_filename + "_tmp_result"
         tmp_result_filename_reduced = tmp_result_filename + '_reduced'
         cmd = ('cat ' + tmp_filename + " " +
                os.path.join(nhsf_path, nhsf_prefix + timeinfo) +

--- a/nwcsafpps_runner/utils.py
+++ b/nwcsafpps_runner/utils.py
@@ -588,13 +588,13 @@ def get_xml_outputfiles(path, platform_name, orb, st_time=''):
 
 
 def create_xml_timestat_from_lvl1c(scene, pps_control_path):
-    """From lvl1c file create XML file and return a file list, v2021."""
+    """From lvl1c file create XML file and return a file list."""
     try:
         txt_time_control = create_pps_file_from_lvl1c(scene['file4pps'], pps_control_path, "timectrl", ".txt")
     except KeyError:
         return []
     if os.path.exists(txt_time_control):
-        return create_xml_timestat_from_ascii(txt_time_control, pps_control_path) 
+        return create_xml_timestat_from_ascii(txt_time_control, pps_control_path)
     else:
         LOG.warning('No XML Time statistics file created!')
         return []


### PR DESCRIPTION
Create the xml files for PPS time controll. The creation of files was removed by mistake in PR #54

<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest nwcsafpps_runner`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8 nwcsafpps_runner`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
